### PR TITLE
use template strings, simplified object literals, spread operator, arrows

### DIFF
--- a/step6/source/script/app.js
+++ b/step6/source/script/app.js
@@ -4,9 +4,7 @@ import logo from 'image/logo.png';
 import search from 'script/search.js';
 
 document.getElementById("app").innerHTML = template({
-    images: {
-        logo: logo
-    },
-    styles: styles,
-    search: search.template
+    images: { logo },
+    search: search.template,
+    styles
 });

--- a/step6/source/script/search.js
+++ b/step6/source/script/search.js
@@ -2,17 +2,21 @@ import template from 'template/search.html';
 import styles from 'style/search.css';
 import $ from 'jquery';
 
-var formClass = '.' + styles.search;
+let formClass = `.${ styles.search }`;
 $(document).on('submit', formClass, search);
 
 function search(e) {
-    var query = $(formClass + ' input').val(),
-        url = 'http://api.giphy.com/v1/gifs/search?api_key=dc6zaTOxFJmzC&q=' + query;
+    let query = $(`${ formClass } input`).val(),
+        url = `http://api.giphy.com/v1/gifs/search?api_key=dc6zaTOxFJmzC&q=${ query }`;
 
-    $.getJSON(url, function(response) {
-        var gifs = [];
-        $.each(response.data, function(key, imgData) {
-            gifs.push("<img src='" + imgData.images.fixed_width.url + "' title='" + imgData.caption + "'/>");
+    $.getJSON(url, (response) => {
+        let gifs = [];
+        $.each(response.data, (key, imgData) => {
+            gifs = [
+              ...gifs,
+              `<img src='${ imgData.images.fixed_width.url }'
+                    title='${ imgData.caption }'/>`
+            ];
         });
 
         $("#results").html(gifs.join("") || "<em>Nothing, sorry.</em>");
@@ -22,7 +26,5 @@ function search(e) {
 }
 
 module.exports = {
-    template: template({
-        styles: styles
-    })
+    template: template({ styles })
 };


### PR DESCRIPTION
Changed some usual ES5 stuff to ES6.

-`let` instead of `var` for easier block scope reasoning.
-arrow functions for brevity (sometimes useful for lexical `this`)
-use array spread operator to re-assign instead of mutate
-template strings to avoid string concatenation and allow multiline strings
-simplified object literals: `{ prop: prop }` -> `{ prop }`
