### PR TITLE
destructure template from search.js, babel all the steps

### DIFF
--- a/step3/source/script/app.js
+++ b/step3/source/script/app.js
@@ -1,8 +1,8 @@
 import search from 'script/search.js';
 
-var template = `
-<h1>Find. Anything.</h1>
-${search.template}
+let template = `
+  <h1>Find. Anything.</h1>
+  ${search.template}
 `;
 
 document.getElementById("app").innerHTML = template;

--- a/step3/source/script/search.js
+++ b/step3/source/script/search.js
@@ -1,10 +1,8 @@
 var template = `
-<form class="search">
-   <span class="icon"><i class="fa fa-search fa-2x"></i></span>
-   <input type="search" placeholder="Type...">
-</form>
+  <form class="search">
+     <span class="icon"><i class="fa fa-search fa-2x"></i></span>
+     <input type="search" placeholder="Type...">
+  </form>
 `;
 
-module.exports = {
-    template: template
-};
+module.exports = { template };

--- a/step3/source/style/search.css
+++ b/step3/source/style/search.css
@@ -64,7 +64,7 @@
 
 /*hover*/
 
-.search input:hover, .search input:focus, .search input:active{
+.search input:hover, .search input:focus, .search input:active {
 	outline:none;
 	background: #424652;
 }

--- a/step4/source/script/app.js
+++ b/step4/source/script/app.js
@@ -1,7 +1,5 @@
 import template from 'template/app.html';
 import styles from 'style/app.css';
-import search from 'script/search.js';
+import { template as search } from 'script/search.js';
 
-document.getElementById("app").innerHTML = template({
-    search: search.template
-});
+document.getElementById("app").innerHTML = template({ search });

--- a/step4/source/script/search.js
+++ b/step4/source/script/search.js
@@ -2,7 +2,5 @@ import template from 'template/search.html';
 import styles from 'style/search.css';
 
 module.exports = {
-    template: template({
-        styles: styles
-    })
+    template: template({ styles })
 };

--- a/step4/source/style/search.css
+++ b/step4/source/style/search.css
@@ -64,7 +64,7 @@
 
 /*hover*/
 
-.search input:hover, .search input:focus, .search input:active{
+.search input:hover, .search input:focus, .search input:active {
 	outline:none;
 	background: #424652;
 }

--- a/step5/source/script/app.js
+++ b/step5/source/script/app.js
@@ -1,12 +1,10 @@
 import template from 'template/app.html';
 import styles from 'style/app.css';
 import logo from 'image/logo.png';
-import search from 'script/search.js';
+import { template as search } from 'script/search.js';
 
 document.getElementById("app").innerHTML = template({
-    images: {
-        logo: logo
-    },
-    styles: styles,
-    search: search.template
+    images: { logo },
+    styles,
+    search
 });

--- a/step5/source/script/search.js
+++ b/step5/source/script/search.js
@@ -2,7 +2,5 @@ import template from 'template/search.html';
 import styles from 'style/search.css';
 
 module.exports = {
-    template: template({
-        styles: styles
-    })
+    template: template({ styles })
 };

--- a/step5/source/style/search.css
+++ b/step5/source/style/search.css
@@ -64,7 +64,7 @@
 
 /*hover*/
 
-.search input:hover, .search input:focus, .search input:active{
+.search input:hover, .search input:focus, .search input:active {
 	outline:none;
 	background: #424652;
 }

--- a/step6/source/script/app.js
+++ b/step6/source/script/app.js
@@ -1,10 +1,10 @@
 import template from 'template/app.html';
 import styles from 'style/app.css';
 import logo from 'image/logo.png';
-import search from 'script/search.js';
+import { template as search } from 'script/search.js';
 
 document.getElementById("app").innerHTML = template({
     images: { logo },
-    search: search.template,
+    search,
     styles
 });

--- a/step6/source/style/search.css
+++ b/step6/source/style/search.css
@@ -64,7 +64,7 @@
 
 /*hover*/
 
-.search input:hover, .search input:focus, .search input:active{
+.search input:hover, .search input:focus, .search input:active {
 	outline:none;
 	background: #424652;
 }


### PR DESCRIPTION
Same ES5 to ES5 changes, with one addition:

```
import { template as search } from 'script/search.js'
```
